### PR TITLE
[BUG] Fix clearAllData race condition and getGameEvents underscore filtering

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -473,14 +473,20 @@ export function getGameEvents(playerId?: string, eventType?: string): GameEvent[
             });
         }
 
-        // Optimize: Filter by eventType using filename pattern (if provided)
+        // Optimize: Filter by eventType using filename substring match
+        // Note: Cannot use positional split because event types may contain underscores
+        // (e.g., wolf_kill → "wolf" and "kill" split into separate positions)
         if (eventType) {
             const sanitizedEventType = eventType.replace(/[^a-z0-9_]/gi, '_');
-            eventFiles = eventFiles.filter(f => {
-                const parts = f.split('_');
-                // Check if filename contains eventType in expected position (index 3)
-                return parts.length >= 4 && parts[3] === sanitizedEventType;
-            });
+            const beforeFilter = eventFiles.length;
+            eventFiles = eventFiles.filter(f =>
+                f.includes('_' + sanitizedEventType + '_')
+            );
+            // Fallback: if filename filter excluded everything, reload all event files
+            // and rely on JSON content filtering below
+            if (eventFiles.length === 0 && beforeFilter > 0) {
+                eventFiles = files.filter(f => f.startsWith('game_event_') && f.endsWith('.json'));
+            }
         }
 
         // Load only the filtered files
@@ -569,8 +575,12 @@ export function clearAllData(): void {
         const files = fs.readdirSync(DATA_DIR);
         files.forEach(file => {
             const filePath = path.join(DATA_DIR, file);
-            if (fs.statSync(filePath).isFile() && file.endsWith('.json')) {
-                fs.unlinkSync(filePath);
+            try {
+                if (fs.statSync(filePath).isFile() && (file.endsWith('.json') || file.includes('.tmp.'))) {
+                    fs.unlinkSync(filePath);
+                }
+            } catch {
+                // File may have been removed by atomic write cleanup
             }
         });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Fix `clearAllData()` race condition where `.tmp` files from atomic writes cause `ENOENT` on `stat()`
- Fix `getGameEvents()` event type filtering that breaks for types with underscores (e.g., `wolf_kill` split into `wolf` at position 3)
- Add fallback to reload all event files when filename filter yields empty results

## Test Plan
- [x] Existing game-engine tests continue passing
- [x] New world-engine tests (in #15) validate wolf_kill trigger evaluation works correctly
- [x] clearAllData no longer throws intermittently during parallel test runs

Closes #14