### PR TITLE
[FEATURE] Narrative Output UI with TDD

### DIFF
--- a/__tests__/components/NarrativeOutput.test.tsx
+++ b/__tests__/components/NarrativeOutput.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Unit tests for NarrativeOutput component
+ * Tests NPC response rendering, loading state, lore references, and accessibility
+ *
+ * Refs #19
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NarrativeOutput from '../../components/NarrativeOutput';
+
+describe('NarrativeOutput', () => {
+  describe('Rendering', () => {
+    it('should render nothing when response is empty and not loading', () => {
+      const { container } = render(
+        <NarrativeOutput npcName="Elarin" response="" />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render NPC name and response text', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="The Ember Tower has stood for three hundred years."
+        />
+      );
+
+      expect(screen.getByText('Elarin says:')).toBeInTheDocument();
+      expect(
+        screen.getByText('The Ember Tower has stood for three hundred years.')
+      ).toBeInTheDocument();
+    });
+
+    it('should render with custom NPC name', () => {
+      render(
+        <NarrativeOutput
+          npcName="Thorn"
+          response="I know nothing of the northern pass."
+        />
+      );
+
+      expect(screen.getByText('Thorn says:')).toBeInTheDocument();
+      expect(
+        screen.getByText('I know nothing of the northern pass.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should show loading indicator when loading is true', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="The ancient ruins hold many secrets."
+          loading={true}
+        />
+      );
+
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    });
+
+    it('should show loading indicator even without response', () => {
+      render(
+        <NarrativeOutput npcName="Elarin" response="" loading={true} />
+      );
+
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    });
+
+    it('should not show loading indicator when loading is false', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="The forest is quiet tonight."
+          loading={false}
+        />
+      );
+
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Lore References', () => {
+    it('should display lore titles when loreUsed is provided', () => {
+      const loreUsed = [
+        { id: 'lore-1', title: 'History of the Ember Tower' },
+        { id: 'lore-2', title: 'The Wolf Clan Chronicles' },
+      ];
+
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="The tower was built by the Wolf Clan."
+          loreUsed={loreUsed}
+        />
+      );
+
+      expect(screen.getByText('History of the Ember Tower')).toBeInTheDocument();
+      expect(screen.getByText('The Wolf Clan Chronicles')).toBeInTheDocument();
+    });
+
+    it('should not show lore section when loreUsed is empty', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="I recall nothing of that place."
+          loreUsed={[]}
+        />
+      );
+
+      expect(screen.queryByTestId('lore-references')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have aria-live polite on response container', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="The stars guide travelers through the dark."
+        />
+      );
+
+      const responseContainer = screen.getByTestId('narrative-response');
+      expect(responseContainer).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should have data-testid narrative-output', () => {
+      render(
+        <NarrativeOutput
+          npcName="Elarin"
+          response="Follow the river east to find the ruins."
+        />
+      );
+
+      expect(screen.getByTestId('narrative-output')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import type { Player, NPCMemory, GameEvent, WorldEvent } from '@/lib/types';
 import ActionInput from '@/components/ActionInput';
+import NarrativeOutput from '@/components/NarrativeOutput';
 
 export default function Home() {
   const [player, setPlayer] = useState<Player | null>(null);
@@ -264,12 +265,11 @@ export default function Home() {
               placeholder="Ask Elarin something..."
             />
 
-            {npcResponse && (
-              <div className="bg-purple-900/30 border border-purple-500/30 rounded-lg p-4">
-                <p className="text-sm text-purple-300 font-semibold mb-2">Elarin says:</p>
-                <p className="text-gray-100">{npcResponse}</p>
-              </div>
-            )}
+            <NarrativeOutput
+              npcName="Elarin"
+              response={npcResponse}
+              loading={loading}
+            />
           </div>
         </section>
 

--- a/components/NarrativeOutput.tsx
+++ b/components/NarrativeOutput.tsx
@@ -1,0 +1,67 @@
+/**
+ * NarrativeOutput Component
+ * Displays NPC narrative responses with lore references and loading state
+ * Refs #19
+ */
+
+'use client';
+
+interface NarrativeOutputProps {
+  npcName: string;
+  response: string;
+  loreUsed?: Array<{ id: string; title: string }>;
+  loading?: boolean;
+}
+
+export default function NarrativeOutput({
+  npcName,
+  response,
+  loreUsed,
+  loading = false,
+}: NarrativeOutputProps) {
+  if (!response && !loading) return null;
+
+  return (
+    <div data-testid="narrative-output">
+      <div
+        data-testid="narrative-response"
+        aria-live="polite"
+        className="bg-purple-900/30 border border-purple-500/30 rounded-lg p-4"
+      >
+        <p className="text-sm text-purple-300 font-semibold mb-2">
+          {npcName} says:
+        </p>
+
+        {loading ? (
+          <div
+            data-testid="loading-indicator"
+            className="inline-flex items-center gap-2 text-gray-400"
+          >
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            Typing...
+          </div>
+        ) : (
+          <p className="text-gray-100">{response}</p>
+        )}
+
+        {loreUsed && loreUsed.length > 0 && (
+          <div
+            data-testid="lore-references"
+            className="mt-3 pt-3 border-t border-purple-500/20"
+          >
+            <p className="text-xs text-purple-400 font-semibold mb-1 uppercase tracking-wide">
+              Lore Referenced:
+            </p>
+            <ul className="space-y-1">
+              {loreUsed.map((lore) => (
+                <li key={lore.id} className="text-xs text-purple-300/80">
+                  {lore.title}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add NarrativeOutput component following strict TDD (RED tests first, then GREEN implementation)
- 10 BDD tests covering: rendering, loading state, lore references, accessibility
- Wire into app/page.tsx replacing inline "Elarin says:" display
- Returns null when idle (PRD: response appears only after interaction)
- aria-live="polite" for screen reader updates

## Test Plan
```
PASS __tests__/components/NarrativeOutput.test.tsx
  Rendering: 3 tests
  Loading State: 3 tests
  Lore References: 2 tests
  Accessibility: 2 tests
Tests: 10 passed, 10 total

Full suite: 25 passed, 2 skipped, 566 total, exit 0
```

## Risk/Rollback
Low — replaces inline div with equivalent component. NPC chat behavior unchanged.

Closes #19