### PR TITLE
[FEATURE] Quest Display UI with TDD

### DIFF
--- a/__tests__/components/QuestDisplay.test.tsx
+++ b/__tests__/components/QuestDisplay.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Unit tests for QuestDisplay component
+ * Tests quest list rendering, objective progress, loading state, and accessibility
+ *
+ * Refs #20
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuestDisplay from '../../components/QuestDisplay';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const inProgressQuest = {
+  questId: 'quest-001',
+  status: 'in_progress',
+  objectives: [
+    {
+      id: 'obj-001',
+      description: 'Defeat wolves near Moonvale',
+      currentCount: 2,
+      targetCount: 3,
+      isCompleted: false,
+    },
+  ],
+};
+
+const completedQuest = {
+  questId: 'quest-002',
+  status: 'completed',
+  objectives: [
+    {
+      id: 'obj-002',
+      description: 'Speak with Elarin the Historian',
+      currentCount: 1,
+      targetCount: 1,
+      isCompleted: true,
+    },
+  ],
+};
+
+const multiObjectiveQuest = {
+  questId: 'quest-003',
+  status: 'in_progress',
+  objectives: [
+    {
+      id: 'obj-003',
+      description: 'Collect ancient rune stones',
+      currentCount: 4,
+      targetCount: 5,
+      isCompleted: false,
+    },
+    {
+      id: 'obj-004',
+      description: 'Return to the village shrine',
+      currentCount: 0,
+      targetCount: 1,
+      isCompleted: false,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('QuestDisplay', () => {
+  describe('Empty State', () => {
+    it('should show no quests message when quests array is empty', () => {
+      render(<QuestDisplay quests={[]} />);
+
+      expect(screen.getByText('No active quests')).toBeInTheDocument();
+    });
+
+    it('should not show no quests message when loading', () => {
+      render(<QuestDisplay quests={[]} loading={true} />);
+
+      expect(screen.queryByText('No active quests')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Quest Rendering', () => {
+    it('should display quest with in_progress status badge', () => {
+      render(<QuestDisplay quests={[inProgressQuest]} />);
+
+      expect(screen.getByText('in_progress')).toBeInTheDocument();
+    });
+
+    it('should display quest with completed status badge', () => {
+      render(<QuestDisplay quests={[completedQuest]} />);
+
+      expect(screen.getByText('completed')).toBeInTheDocument();
+    });
+
+    it('should display multiple quests', () => {
+      render(<QuestDisplay quests={[inProgressQuest, completedQuest]} />);
+
+      expect(screen.getByText('in_progress')).toBeInTheDocument();
+      expect(screen.getByText('completed')).toBeInTheDocument();
+    });
+  });
+
+  describe('Objective Progress', () => {
+    it('should show objective description and progress count', () => {
+      render(<QuestDisplay quests={[inProgressQuest]} />);
+
+      expect(
+        screen.getByText('Defeat wolves near Moonvale')
+      ).toBeInTheDocument();
+    });
+
+    it('should show completed objectives with visual indicator', () => {
+      render(<QuestDisplay quests={[completedQuest]} />);
+
+      const completedObjective = screen.getByTestId('objective-obj-002');
+      expect(completedObjective).toHaveAttribute('data-completed', 'true');
+    });
+
+    it('should show progress as fraction (currentCount/targetCount)', () => {
+      render(<QuestDisplay quests={[inProgressQuest]} />);
+
+      expect(screen.getByText('2/3')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should show loading indicator when loading', () => {
+      render(<QuestDisplay quests={[]} loading={true} />);
+
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have data-testid quest-display', () => {
+      render(<QuestDisplay quests={[]} />);
+
+      expect(screen.getByTestId('quest-display')).toBeInTheDocument();
+    });
+
+    it('should have aria-label quest tracker', () => {
+      render(<QuestDisplay quests={[]} />);
+
+      expect(
+        screen.getByRole('region', { name: 'Quest tracker' })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import type { Player, NPCMemory, GameEvent, WorldEvent } from '@/lib/types';
 import ActionInput from '@/components/ActionInput';
 import NarrativeOutput from '@/components/NarrativeOutput';
+import QuestDisplay from '@/components/QuestDisplay';
 
 export default function Home() {
   const [player, setPlayer] = useState<Player | null>(null);
@@ -16,6 +17,7 @@ export default function Home() {
   const [lore, setLore] = useState<any[]>([]);
   const [loreSearchQuery, setLoreSearchQuery] = useState('');
   const [stats, setStats] = useState<any>(null);
+  const [quests, setQuests] = useState<any[]>([]);
   const [showAIKitDemo, setShowAIKitDemo] = useState(false);
   const [aiKitPrompt, setAIKitPrompt] = useState('');
 
@@ -26,6 +28,7 @@ export default function Home() {
     fetchWorldState();
     fetchLore();
     fetchStats();
+    fetchQuests();
   }, []);
 
   const fetchPlayer = async () => {
@@ -192,6 +195,31 @@ export default function Home() {
     }
   };
 
+  const fetchQuests = async () => {
+    if (!player) return;
+    try {
+      const progressRes = await fetch(`/api/quest/progress?playerId=${player.id}&questId=default`);
+      if (progressRes.ok) {
+        const progress = await progressRes.json();
+        if (progress.questId) {
+          const objRes = await fetch(`/api/quest/objectives?questId=${progress.questId}`);
+          if (objRes.ok) {
+            const objectives = await objRes.json();
+            setQuests([{
+              questId: progress.questId,
+              status: progress.status,
+              objectives: Array.isArray(objectives) ? objectives : [],
+            }]);
+            return;
+          }
+        }
+      }
+      setQuests([]);
+    } catch (error) {
+      console.error('Error fetching quests:', error);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-gradient-to-b from-slate-900 via-purple-900 to-slate-900 text-white p-8">
       <div className="max-w-7xl mx-auto space-y-8">
@@ -300,6 +328,12 @@ export default function Home() {
               Help Village
             </button>
           </div>
+        </section>
+
+        {/* Quest Tracker */}
+        <section className="bg-slate-800/50 backdrop-blur rounded-lg p-6 border border-purple-500/20 shadow-xl">
+          <h3 className="text-2xl font-bold mb-4 text-purple-300">Quest Tracker</h3>
+          <QuestDisplay quests={quests} loading={loading && quests.length === 0} />
         </section>
 
         {/* Section 5: World Events Panel */}

--- a/components/QuestDisplay.tsx
+++ b/components/QuestDisplay.tsx
@@ -1,0 +1,92 @@
+/**
+ * QuestDisplay Component
+ * Shows active quests with objective progress tracking
+ * Refs #20
+ */
+
+'use client';
+
+interface QuestObjectiveView {
+  id: string;
+  description: string;
+  currentCount: number;
+  targetCount: number;
+  isCompleted: boolean;
+}
+
+interface QuestView {
+  questId: string;
+  status: string;
+  objectives: QuestObjectiveView[];
+}
+
+interface QuestDisplayProps {
+  quests: QuestView[];
+  loading?: boolean;
+}
+
+export default function QuestDisplay({
+  quests,
+  loading = false,
+}: QuestDisplayProps) {
+  return (
+    <section
+      data-testid="quest-display"
+      role="region"
+      aria-label="Quest tracker"
+    >
+      {loading ? (
+        <div
+          data-testid="loading-indicator"
+          className="inline-flex items-center gap-2 text-gray-400"
+        >
+          <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          Loading quests...
+        </div>
+      ) : quests.length === 0 ? (
+        <p className="text-gray-400 italic">No active quests</p>
+      ) : (
+        <div className="space-y-3">
+          {quests.map((quest) => (
+            <div
+              key={quest.questId}
+              className="bg-slate-700/30 border border-slate-600/30 rounded-lg p-4"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span
+                  className={`text-xs font-semibold px-2 py-1 rounded ${
+                    quest.status === 'completed'
+                      ? 'bg-green-600/30 text-green-300'
+                      : quest.status === 'failed'
+                      ? 'bg-red-600/30 text-red-300'
+                      : 'bg-yellow-600/30 text-yellow-300'
+                  }`}
+                >
+                  {quest.status}
+                </span>
+              </div>
+
+              <div className="space-y-2">
+                {quest.objectives.map((obj) => (
+                  <div
+                    key={obj.id}
+                    data-testid={`objective-${obj.id}`}
+                    data-completed={obj.isCompleted ? 'true' : 'false'}
+                    className={`flex items-center justify-between text-sm ${
+                      obj.isCompleted ? 'text-green-300 line-through' : 'text-gray-300'
+                    }`}
+                  >
+                    <span>{obj.description}</span>
+                    <span className="text-xs font-mono ml-2">
+                      {obj.currentCount}/{obj.targetCount}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add QuestDisplay component following strict TDD (RED → GREEN)
- 11 BDD tests: empty state, status badges, objective progress fractions, completed indicators, loading, accessibility
- Wire into app/page.tsx with Quest Tracker section, quests state, fetchQuests API call
- Placed between Actions and World Events panels per page layout

## Test Plan
```
PASS __tests__/components/QuestDisplay.test.tsx
  Empty State: 2 tests
  Quest Rendering: 3 tests
  Objective Progress: 3 tests
  Loading State: 1 test
  Accessibility: 2 tests
Tests: 11 passed, 11 total

Full suite: 26 passed, 2 skipped, 577 total, exit 0
```

## Risk/Rollback
Low — adds new section, does not modify existing sections. Revert single commit.

Closes #20