### PR TITLE
[FEATURE] Demo Scenario system matching PRD Section 8

### DIFF
--- a/__tests__/demo.test.ts
+++ b/__tests__/demo.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for lib/demo.ts — Demo Scenario (Issue #22)
+ *
+ * Verifies the full 2-minute demo script from PRD Section 8:
+ *   Step 1: Create Player
+ *   Step 2: Ask NPC "What happened to Ember Tower?" → NPC answers using lore
+ *   Steps 3-5: Click Fight Wolf × 3
+ *   Step 4 (auto): World Event "Wolf Pack Retreat" triggers on 3rd wolf kill
+ *   Step 6: Talk to NPC again → NPC references wolf memory
+ *
+ * Refs #22
+ */
+
+import {
+    getDemoSteps,
+    executeDemoStep,
+    runFullDemo,
+    DemoStep,
+    DemoStepResult,
+} from '../lib/demo';
+import { clearAllData } from '../lib/data';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEMO_STEP_COUNT = 6;
+const EMBER_TOWER_STEP_ID = 'ask_ember_tower';
+const WOLF_KILL_STEP_IDS = ['fight_wolf_1', 'fight_wolf_2', 'fight_wolf_3'];
+const NPC_MEMORY_STEP_ID = 'ask_about_wolves';
+const CREATE_PLAYER_STEP_ID = 'create_player';
+
+// ---------------------------------------------------------------------------
+// Test Suite
+// ---------------------------------------------------------------------------
+
+describe('Demo Scenario', () => {
+    beforeEach(() => {
+        clearAllData();
+    });
+
+    afterEach(() => {
+        clearAllData();
+    });
+
+    // -----------------------------------------------------------------------
+    // getDemoSteps
+    // -----------------------------------------------------------------------
+
+    describe('getDemoSteps', () => {
+        it('should return 6 ordered demo steps', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert
+            expect(steps).toBeDefined();
+            expect(Array.isArray(steps)).toBe(true);
+            expect(steps.length).toBe(DEMO_STEP_COUNT);
+        });
+
+        it('should return steps with required fields on each step', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert — every step must carry all required fields
+            steps.forEach((step: DemoStep) => {
+                expect(step.id).toBeDefined();
+                expect(typeof step.id).toBe('string');
+                expect(step.action).toBeDefined();
+                expect(typeof step.action).toBe('string');
+                expect(step.description).toBeDefined();
+                expect(typeof step.description).toBe('string');
+                expect(step.expectedOutcome).toBeDefined();
+                expect(typeof step.expectedOutcome).toBe('string');
+            });
+        });
+
+        it('should include Ember Tower question step', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert
+            const emberStep = steps.find((s: DemoStep) => s.id === EMBER_TOWER_STEP_ID);
+            expect(emberStep).toBeDefined();
+            expect(emberStep!.action).toMatch(/ember tower/i);
+        });
+
+        it('should include 3 wolf kill steps', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert — all three wolf kill step IDs must be present
+            WOLF_KILL_STEP_IDS.forEach(wolfStepId => {
+                const wolfStep = steps.find((s: DemoStep) => s.id === wolfStepId);
+                expect(wolfStep).toBeDefined();
+                expect(wolfStep!.action).toMatch(/wolf/i);
+            });
+        });
+
+        it('should include final NPC memory check step', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert
+            const memoryStep = steps.find((s: DemoStep) => s.id === NPC_MEMORY_STEP_ID);
+            expect(memoryStep).toBeDefined();
+            expect(memoryStep!.expectedOutcome).toMatch(/wolf/i);
+        });
+
+        it('should list create_player as the first step', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert
+            expect(steps[0].id).toBe(CREATE_PLAYER_STEP_ID);
+        });
+
+        it('should list NPC memory check as the last step', () => {
+            // Arrange / Act
+            const steps = getDemoSteps();
+
+            // Assert
+            expect(steps[steps.length - 1].id).toBe(NPC_MEMORY_STEP_ID);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // executeDemoStep
+    // -----------------------------------------------------------------------
+
+    describe('executeDemoStep', () => {
+        it('should create player on step 1', async () => {
+            // Act
+            const result = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+
+            // Assert
+            expect(result).toBeDefined();
+            expect(result.stepId).toBe(CREATE_PLAYER_STEP_ID);
+            expect(result.success).toBe(true);
+            expect(result.data).toBeDefined();
+            expect(result.data.player).toBeDefined();
+            expect(result.data.player.id).toBeDefined();
+            expect(typeof result.data.player.username).toBe('string');
+            expect(result.data.player.username.length).toBeGreaterThan(0);
+        });
+
+        it('should get NPC response about Ember Tower on step 2', async () => {
+            // Arrange — player must exist before NPC interaction
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            // Act
+            const result = await executeDemoStep(EMBER_TOWER_STEP_ID, playerId);
+
+            // Assert
+            expect(result.success).toBe(true);
+            expect(result.stepId).toBe(EMBER_TOWER_STEP_ID);
+            expect(result.data.npcResponse).toBeDefined();
+            expect(typeof result.data.npcResponse.response).toBe('string');
+            expect(result.data.npcResponse.response.toLowerCase()).toMatch(/ember tower/i);
+        });
+
+        it('should reference lore when responding to Ember Tower question', async () => {
+            // Arrange
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            // Act
+            const result = await executeDemoStep(EMBER_TOWER_STEP_ID, playerId);
+
+            // Assert — lore retrieval is core to the demo proof point
+            expect(result.data.npcResponse.loreUsed).toBeDefined();
+            expect(Array.isArray(result.data.npcResponse.loreUsed)).toBe(true);
+            expect(result.data.npcResponse.loreUsed.length).toBeGreaterThan(0);
+        });
+
+        it('should create wolf kill events on steps 3-5', async () => {
+            // Arrange
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            // Act — first two wolf kills
+            const kill1 = await executeDemoStep('fight_wolf_1', playerId);
+            const kill2 = await executeDemoStep('fight_wolf_2', playerId);
+
+            // Assert
+            expect(kill1.success).toBe(true);
+            expect(kill1.data.gameEvent).toBeDefined();
+            expect(kill1.data.gameEvent.player_id).toBe(playerId);
+
+            expect(kill2.success).toBe(true);
+            expect(kill2.data.gameEvent).toBeDefined();
+            expect(kill2.data.gameEvent.player_id).toBe(playerId);
+        });
+
+        it('should not trigger Wolf Pack Retreat on steps 3 or 4', async () => {
+            // Arrange
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            // Act
+            const kill1 = await executeDemoStep('fight_wolf_1', playerId);
+            const kill2 = await executeDemoStep('fight_wolf_2', playerId);
+
+            // Assert — world event must not fire before the 3rd kill
+            expect(kill1.data.worldEvent).toBeUndefined();
+            expect(kill2.data.worldEvent).toBeUndefined();
+        });
+
+        it('should trigger Wolf Pack Retreat on step 5 (3rd wolf kill)', async () => {
+            // Arrange
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            await executeDemoStep('fight_wolf_1', playerId);
+            await executeDemoStep('fight_wolf_2', playerId);
+
+            // Act — third kill is the trigger
+            const kill3 = await executeDemoStep('fight_wolf_3', playerId);
+
+            // Assert
+            expect(kill3.success).toBe(true);
+            expect(kill3.data.worldEvent).toBeDefined();
+            expect(kill3.data.worldEvent.event_name).toBe('Wolf Pack Retreat');
+            expect(kill3.data.worldEvent.trigger_source).toBe(playerId);
+        });
+
+        it('should get NPC response referencing wolf memory on step 6', async () => {
+            // Arrange — run through all preceding steps
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            await executeDemoStep(EMBER_TOWER_STEP_ID, playerId);
+            await executeDemoStep('fight_wolf_1', playerId);
+            await executeDemoStep('fight_wolf_2', playerId);
+            await executeDemoStep('fight_wolf_3', playerId);
+
+            // Act
+            const result = await executeDemoStep(NPC_MEMORY_STEP_ID, playerId);
+
+            // Assert — NPC must surface wolf-related memory in the response
+            expect(result.success).toBe(true);
+            expect(result.data.npcResponse).toBeDefined();
+            expect(result.data.npcResponse.response.toLowerCase()).toMatch(/wolf|wolves/);
+        });
+
+        it('should include memoriesReferenced in final NPC response', async () => {
+            // Arrange
+            const playerResult = await executeDemoStep(CREATE_PLAYER_STEP_ID);
+            const playerId = playerResult.data.player.id;
+
+            await executeDemoStep(EMBER_TOWER_STEP_ID, playerId);
+            await executeDemoStep('fight_wolf_1', playerId);
+            await executeDemoStep('fight_wolf_2', playerId);
+            await executeDemoStep('fight_wolf_3', playerId);
+
+            // Act
+            const result = await executeDemoStep(NPC_MEMORY_STEP_ID, playerId);
+
+            // Assert — memory array proves the NPC remembers player's actions
+            expect(result.data.npcResponse.memoriesReferenced).toBeDefined();
+            expect(Array.isArray(result.data.npcResponse.memoriesReferenced)).toBe(true);
+            expect(result.data.npcResponse.memoriesReferenced.length).toBeGreaterThan(0);
+        });
+
+        it('should return an error result when playerId is missing for NPC steps', async () => {
+            // Act — no playerId supplied for a step that requires one
+            const result = await executeDemoStep(EMBER_TOWER_STEP_ID, undefined);
+
+            // Assert
+            expect(result.success).toBe(false);
+            expect(result.error).toBeDefined();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // runFullDemo
+    // -----------------------------------------------------------------------
+
+    describe('runFullDemo', () => {
+        it('should execute all steps and return results', async () => {
+            // Act
+            const results = await runFullDemo();
+
+            // Assert
+            expect(results).toBeDefined();
+            expect(Array.isArray(results)).toBe(true);
+            expect(results.length).toBe(DEMO_STEP_COUNT);
+        });
+
+        it('should mark every step as successful', async () => {
+            // Act
+            const results = await runFullDemo();
+
+            // Assert
+            results.forEach((result: DemoStepResult) => {
+                expect(result.success).toBe(true);
+            });
+        });
+
+        it('should trigger exactly one world event across the full demo', async () => {
+            // Act
+            const results = await runFullDemo();
+
+            // Assert — count world events from results
+            const worldEvents = results
+                .map((r: DemoStepResult) => r.data?.worldEvent)
+                .filter(Boolean);
+
+            expect(worldEvents.length).toBe(1);
+            expect(worldEvents[0].event_name).toBe('Wolf Pack Retreat');
+        });
+
+        it('should produce results in the same order as getDemoSteps', async () => {
+            // Arrange
+            const steps = getDemoSteps();
+
+            // Act
+            const results = await runFullDemo();
+
+            // Assert — result order must mirror step definition order
+            results.forEach((result: DemoStepResult, index: number) => {
+                expect(result.stepId).toBe(steps[index].id);
+            });
+        });
+
+        it('should carry a player id through all steps after creation', async () => {
+            // Act
+            const results = await runFullDemo();
+
+            // Assert — every result after the first should reference the same player
+            const playerId = results[0].data?.player?.id;
+            expect(playerId).toBeDefined();
+
+            // All subsequent results that carry a player reference must match
+            results.slice(1).forEach((result: DemoStepResult) => {
+                if (result.data?.player) {
+                    expect(result.data.player.id).toBe(playerId);
+                }
+            });
+        });
+    });
+});

--- a/lib/demo.ts
+++ b/lib/demo.ts
@@ -1,0 +1,244 @@
+/**
+ * Demo Scenario for ZDBGame - Moonvale 2-Minute Demo
+ *
+ * Implements the full demo script from PRD Section 8:
+ *   Step 1: Create Player
+ *   Step 2: Ask NPC "What happened to Ember Tower?" — NPC answers using lore
+ *   Steps 3-5: Fight Wolf × 3
+ *   Step 4 (auto): World Event "Wolf Pack Retreat" triggers on 3rd wolf kill
+ *   Step 6: Talk to NPC again — NPC references wolf memory
+ *
+ * Refs #22
+ */
+
+import { savePlayer } from './data';
+import { processGameplayEvent } from './game-engine';
+import { generateNPCResponse, storeActionMemory } from './npc';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DemoStep {
+    id: string;
+    action: string;
+    description: string;
+    expectedOutcome: string;
+}
+
+export interface DemoStepResult {
+    stepId: string;
+    success: boolean;
+    data: any;
+    error?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Fixed NPC ID for Elarin, the Village Historian used throughout the demo */
+const DEMO_NPC_ID = 'elarin-1';
+
+/** Default player definition for the demo */
+const DEMO_PLAYER = {
+    username: 'DemoAdventurer',
+    class: 'Ranger',
+    faction: 'Forest Guild',
+    level: 1,
+    xp: 0,
+    inventory: [],
+    reputation: 0,
+};
+
+// ============================================================================
+// getDemoSteps
+// ============================================================================
+
+/**
+ * Returns the ordered list of demo steps that constitute the 2-minute demo.
+ * Steps map directly to executeDemoStep() calls.
+ */
+export function getDemoSteps(): DemoStep[] {
+    return [
+        {
+            id: 'create_player',
+            action: 'Create a new player character',
+            description: 'Initialize a new adventurer who will explore Moonvale',
+            expectedOutcome: 'Player is created with a unique ID and default stats',
+        },
+        {
+            id: 'ask_ember_tower',
+            action: 'Ask Elarin about the ember tower',
+            description: 'Player queries the village historian about Ember Tower history',
+            expectedOutcome: 'NPC responds with lore about Ember Tower drawn from the knowledge base',
+        },
+        {
+            id: 'fight_wolf_1',
+            action: 'Fight and defeat a wolf (1st wolf kill)',
+            description: 'Player engages a wolf near the northern forest',
+            expectedOutcome: 'Wolf kill event recorded; no world event yet',
+        },
+        {
+            id: 'fight_wolf_2',
+            action: 'Fight and defeat a wolf (2nd wolf kill)',
+            description: 'Player defeats a second wolf patrolling the forest edge',
+            expectedOutcome: 'Second wolf kill recorded; world event threshold not yet reached',
+        },
+        {
+            id: 'fight_wolf_3',
+            action: 'Fight and defeat a wolf (3rd wolf kill)',
+            description: 'Player slays a third wolf, tipping the balance in Moonvale',
+            expectedOutcome: 'Third wolf kill triggers the Wolf Pack Retreat world event',
+        },
+        {
+            id: 'ask_about_wolves',
+            action: 'Ask Elarin about wolves and recent events',
+            description: 'Player returns to the historian after driving off the wolves',
+            expectedOutcome: 'NPC references the wolf kills in their response, demonstrating persistent memory',
+        },
+    ];
+}
+
+// ============================================================================
+// executeDemoStep
+// ============================================================================
+
+/**
+ * Execute a single demo step by ID.
+ *
+ * NPC steps require a playerId; if omitted they return an error result.
+ * Wolf kill steps also store action memories so the NPC can reference them later.
+ */
+export async function executeDemoStep(
+    stepId: string,
+    playerId?: string,
+): Promise<DemoStepResult> {
+    try {
+        switch (stepId) {
+            case 'create_player': {
+                const player = savePlayer(DEMO_PLAYER);
+                return {
+                    stepId,
+                    success: true,
+                    data: { player },
+                };
+            }
+
+            case 'ask_ember_tower': {
+                if (!playerId) {
+                    return {
+                        stepId,
+                        success: false,
+                        error: 'playerId is required',
+                        data: {},
+                    };
+                }
+                const npcResponse = await generateNPCResponse(
+                    DEMO_NPC_ID,
+                    playerId,
+                    'What happened to the ember tower?',
+                );
+                return {
+                    stepId,
+                    success: true,
+                    data: { npcResponse },
+                };
+            }
+
+            case 'fight_wolf_1':
+            case 'fight_wolf_2':
+            case 'fight_wolf_3': {
+                if (!playerId) {
+                    return {
+                        stepId,
+                        success: false,
+                        error: 'playerId is required',
+                        data: {},
+                    };
+                }
+                const { gameEvent, worldEvent } = processGameplayEvent(
+                    playerId,
+                    'wolf_kill',
+                    'Player defeated a wolf near the northern forest',
+                    'Northern Forest',
+                );
+                // Store NPC memory of the wolf kill so Elarin can reference it
+                await storeActionMemory(DEMO_NPC_ID, playerId, 'wolf_kill');
+                return {
+                    stepId,
+                    success: true,
+                    data: worldEvent ? { gameEvent, worldEvent } : { gameEvent },
+                };
+            }
+
+            case 'ask_about_wolves': {
+                if (!playerId) {
+                    return {
+                        stepId,
+                        success: false,
+                        error: 'playerId is required',
+                        data: {},
+                    };
+                }
+                const npcResponse = await generateNPCResponse(
+                    DEMO_NPC_ID,
+                    playerId,
+                    'Tell me about wolves',
+                );
+                return {
+                    stepId,
+                    success: true,
+                    data: { npcResponse },
+                };
+            }
+
+            default: {
+                return {
+                    stepId,
+                    success: false,
+                    error: `Unknown step ID: ${stepId}`,
+                    data: {},
+                };
+            }
+        }
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+            stepId,
+            success: false,
+            error: message,
+            data: {},
+        };
+    }
+}
+
+// ============================================================================
+// runFullDemo
+// ============================================================================
+
+/**
+ * Run the complete 2-minute demo from start to finish.
+ *
+ * Executes all steps in order, threading the playerId created in step 1
+ * through every subsequent step.
+ *
+ * Returns the ordered array of DemoStepResult values.
+ */
+export async function runFullDemo(): Promise<DemoStepResult[]> {
+    const steps = getDemoSteps();
+    const results: DemoStepResult[] = [];
+    let playerId: string | undefined;
+
+    for (const step of steps) {
+        const result = await executeDemoStep(step.id, playerId);
+        results.push(result);
+
+        // Capture the playerId from the create_player step
+        if (step.id === 'create_player' && result.success && result.data?.player?.id) {
+            playerId = result.data.player.id;
+        }
+    }
+
+    return results;
+}


### PR DESCRIPTION
## Summary
- Add lib/demo.ts implementing the full PRD Section 8 demo script programmatically
- 6-step scenario: Create Player → Ask Ember Tower → Fight Wolf x3 → NPC Memory Check
- getDemoSteps() defines the scenario, executeDemoStep() runs individual steps, runFullDemo() orchestrates the full sequence
- Proves all 5 PRD demo goals: persistent player, NPC memory, lore retrieval, telemetry, emergent world events
- Stores NPC memories during wolf kills for the "wow" moment

## Test Plan
```
PASS __tests__/demo.test.ts
  getDemoSteps: 7 tests
  executeDemoStep: 9 tests
  runFullDemo: 5 tests
Tests: 21 passed, 21 total

Full suite: 30 passed, 2 skipped, 619 total, exit 0
```

## Risk/Rollback
Low — adds new module, no existing code modified. Revert single commit.

Closes #22