### PR TITLE
[BUG] Fix dashboard API mismatches and add auto-seed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,13 +23,15 @@ export default function Home() {
   const [aiKitPrompt, setAIKitPrompt] = useState('');
 
   useEffect(() => {
-    fetchPlayer();
-    fetchMemories();
-    fetchEvents();
-    fetchWorldState();
-    fetchLore();
-    fetchStats();
-    fetchQuests();
+    seedWorldIfEmpty().then(() => {
+      fetchPlayer();
+      fetchMemories();
+      fetchEvents();
+      fetchWorldState();
+      fetchLore();
+      fetchStats();
+      fetchQuests();
+    });
   }, []);
 
   const fetchPlayer = async () => {
@@ -37,10 +39,24 @@ export default function Home() {
       const res = await fetch('/api/player/current');
       if (res.ok) {
         const data = await res.json();
-        setPlayer(data);
+        setPlayer(data.player || data);
       }
     } catch (error) {
       console.error('Error fetching player:', error);
+    }
+  };
+
+  const seedWorldIfEmpty = async () => {
+    try {
+      const res = await fetch('/api/admin/reset', { method: 'GET' });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.status?.loreCount === 0) {
+          await fetch('/api/admin/reset', { method: 'POST' });
+        }
+      }
+    } catch (error) {
+      console.error('Error seeding world:', error);
     }
   };
 
@@ -50,8 +66,10 @@ export default function Home() {
       const res = await fetch('/api/player/create', { method: 'POST' });
       if (res.ok) {
         const data = await res.json();
-        setPlayer(data);
+        setPlayer(data.player || data);
         await fetchWorldState();
+        await fetchMemories();
+        await fetchEvents();
       }
     } catch (error) {
       console.error('Error creating player:', error);


### PR DESCRIPTION
## Summary
- Fix player data not displaying: API returns `{ success, player }` but page used raw `data` — now uses `data.player || data`
- Fix NPC "not found": add `seedWorldIfEmpty()` that auto-seeds Elarin + 3 lore entries on first page load
- Fix actions not updating display: re-fetch memories/events/world after player creation

## Test Plan
```
Full suite: 30 passed, 2 skipped, 619 total, exit 0
```

Manual E2E verification via curl:
- POST /api/admin/reset → seeds Elarin + 3 lore
- POST /api/player/create → returns player with username/class/level/xp
- POST /api/npc/talk → Elarin responds about Ember Tower with lore
- POST /api/event/create → wolf_kill creates event + stores NPC memory
- GET /api/memories → returns wolf kill memory

## Risk/Rollback
Low — changes only page.tsx data handling. No API routes modified.

Closes #34